### PR TITLE
README: "warp" -> "wrapper"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ python3 -m pip install libpagure
 >>> Project "foo" created
 ```
 
-This library is a Python warp of Pagure web APIs.
+This library is a Python wrapper of Pagure web APIs.
 You can refer to [Pagure API](https://pagure.io/api/0/) reference.


### PR DESCRIPTION
Fix the misspelling of "wrap" in the README.